### PR TITLE
Alert when accordion sections are empty

### DIFF
--- a/lib/navigation_page_quality.rb
+++ b/lib/navigation_page_quality.rb
@@ -25,6 +25,19 @@ class NavigationPageQuality
         warnings << "#{url} has no tagged content shown"
       end
 
+      if page_type == "accordion"
+        subsections = doc.css('.topic-content .subsection')
+
+        subsections.each do |subsection|
+          subsection_title = subsection.css('.subsection-title').text
+          content_links = subsection.css('.subsection-content ol li a')
+
+          if content_links.count == 0
+            warnings << "Accordion subsection #{subsection_title} in #{url} doesn't have content"
+          end
+        end
+      end
+
       size
     end
 


### PR DESCRIPTION
We shouldn't have accordion sections without any content. This change
makes sure we get a slack notification when there is a taxon in an
accordion subsection without any content.

Trello: https://trello.com/c/NEYdRp4c/486-implement-regular-check-of-taxon-navigation-pages