### PR TITLE
See what taxonomy pages we analyse and errors

### DIFF
--- a/lib/navigation_page_quality.rb
+++ b/lib/navigation_page_quality.rb
@@ -16,6 +16,7 @@ class NavigationPageQuality
     pages = HTTP.get_multiple(navigation_urls)
 
     pages.map do |url, page|
+      puts "Analysing taxonomy page #{url}"
       doc = Nokogiri::HTML(page)
 
       page_type = doc.css('meta[name="govuk:navigation-page-type"]').attr("content").to_s
@@ -51,6 +52,8 @@ class NavigationPageQuality
       }
 
       HTTP.post(ENV["BADGER_SLACK_WEBHOOK_URL"], body: JSON.dump(message_payload))
+
+      puts message_payload[:text]
     end
   end
 


### PR DESCRIPTION
This commit adds some output so we can see in Jenkins what pages get
analysed and what errors there were, if any.

The errors are especially important since the slack history goes away
after a few days.