### PR TITLE
Add number of taxon tags and base paths to output

### DIFF
--- a/lib/analysers/taxons/accordion_link_analyser.rb
+++ b/lib/analysers/taxons/accordion_link_analyser.rb
@@ -11,6 +11,9 @@ module Analysers
             .at_css(CssSelector.for(:accordion_subsection_title))
             .text.strip
 
+          section_links_total = link.ancestors(CssSelector.for(:accordion_subsection))
+            .css(CssSelector.for(:accordion_content_item_links)).count
+
           link_href = link.attr('href')
           link_base_path = link_href.split('https://www.gov.uk').last
 
@@ -25,6 +28,7 @@ module Analysers
           results << {
             taxon_base_path: taxon.base_path,
             link_href: link_href,
+            total_number_of_links_per_section: section_links_total,
             navigation_page_type: taxon.navigation_page_type,
             section: section,
             number_of_tags: number_of_tags,

--- a/lib/analysers/taxons/accordion_link_analyser.rb
+++ b/lib/analysers/taxons/accordion_link_analyser.rb
@@ -4,6 +4,8 @@ module Analysers
       def analyse(taxon)
         return [] unless taxon.is_accordion?
 
+        total_links = taxon.body_html.css(CssSelector.for(:accordion_content_item_links)).count
+
         taxon.body_html.css(CssSelector.for(:accordion_content_item_links))
           .reduce([]) do |results, link|
 
@@ -28,6 +30,7 @@ module Analysers
           results << {
             taxon_base_path: taxon.base_path,
             link_href: link_href,
+            total_number_of_links: total_links,
             total_number_of_links_per_section: section_links_total,
             navigation_page_type: taxon.navigation_page_type,
             section: section,

--- a/lib/analysers/taxons/accordion_link_analyser.rb
+++ b/lib/analysers/taxons/accordion_link_analyser.rb
@@ -11,11 +11,24 @@ module Analysers
             .at_css(CssSelector.for(:accordion_subsection_title))
             .text.strip
 
+          link_href = link.attr('href')
+          link_base_path = link_href.split('https://www.gov.uk').last
+
+          content_item = HTTP.get_json(
+            "https://www.gov.uk/api/content#{link_base_path}"
+          )
+
+          taxon_tags = content_item['links']['taxons']
+          number_of_tags = taxon_tags.count
+          taxon_base_paths = taxon_tags.map { |taxon| taxon['base_path'] }
+
           results << {
             taxon_base_path: taxon.base_path,
-            link_href: link.attr('href'),
+            link_href: link_href,
             navigation_page_type: taxon.navigation_page_type,
             section: section,
+            number_of_tags: number_of_tags,
+            taxon_base_paths: taxon_base_paths.join(';'),
           }
         end
       end

--- a/lib/analysers/taxons/grid_and_leaf_link_analyser.rb
+++ b/lib/analysers/taxons/grid_and_leaf_link_analyser.rb
@@ -14,6 +14,7 @@ module Analysers
           results << {
             taxon_base_path: taxon.base_path,
             link_href: link.attr('href'),
+            total_number_of_links_per_section: 'N/A',
             navigation_page_type: taxon.navigation_page_type,
             section: 'grid',
             number_of_tags: 'N/A',
@@ -25,6 +26,9 @@ module Analysers
       def leaf_results(taxon)
         taxon.body_html.css(CssSelector.for(:leaf_content_item_links))
           .reduce([]) do |results, link|
+
+          section_links_total = link.ancestors(CssSelector.for(:leaf_subsection))
+            .css(CssSelector.for(:leaf_content_item_links)).count
 
           link_href = link.attr('href')
           link_base_path = link_href.split('https://www.gov.uk').last
@@ -40,6 +44,7 @@ module Analysers
           results << {
             taxon_base_path: taxon.base_path,
             link_href: link.attr('href'),
+            total_number_of_links_per_section: section_links_total,
             navigation_page_type: taxon.navigation_page_type,
             section: 'leaf',
             number_of_tags: number_of_tags,

--- a/lib/analysers/taxons/grid_and_leaf_link_analyser.rb
+++ b/lib/analysers/taxons/grid_and_leaf_link_analyser.rb
@@ -8,30 +8,42 @@ module Analysers
       end
 
       def grid_results(taxon)
-        fetch_links(
-          taxon: taxon,
-          css_selector: CssSelector.for(:grid_taxon_links),
-          section: 'grid',
-        )
-      end
-
-      def leaf_results(taxon)
-        fetch_links(
-          taxon: taxon,
-          css_selector: CssSelector.for(:leaf_content_item_links),
-          section: 'leaf',
-        )
-      end
-
-      def fetch_links(taxon:, css_selector:, section:)
-        taxon.body_html.css(css_selector)
+        taxon.body_html.css(CssSelector.for(:grid_taxon_links))
           .reduce([]) do |results, link|
 
           results << {
             taxon_base_path: taxon.base_path,
             link_href: link.attr('href'),
             navigation_page_type: taxon.navigation_page_type,
-            section: section,
+            section: 'grid',
+            number_of_tags: 'N/A',
+            taxon_base_paths: 'N/A',
+          }
+        end
+      end
+
+      def leaf_results(taxon)
+        taxon.body_html.css(CssSelector.for(:leaf_content_item_links))
+          .reduce([]) do |results, link|
+
+          link_href = link.attr('href')
+          link_base_path = link_href.split('https://www.gov.uk').last
+
+          content_item = HTTP.get_json(
+            "https://www.gov.uk/api/content#{link_base_path}"
+          )
+
+          taxon_tags = content_item['links']['taxons']
+          number_of_tags = taxon_tags.count
+          taxon_base_paths = taxon_tags.map { |taxon| taxon['base_path'] }
+
+          results << {
+            taxon_base_path: taxon.base_path,
+            link_href: link.attr('href'),
+            navigation_page_type: taxon.navigation_page_type,
+            section: 'leaf',
+            number_of_tags: number_of_tags,
+            taxon_base_paths: taxon_base_paths.join(';'),
           }
         end
       end

--- a/lib/analysers/taxons/grid_and_leaf_link_analyser.rb
+++ b/lib/analysers/taxons/grid_and_leaf_link_analyser.rb
@@ -14,6 +14,7 @@ module Analysers
           results << {
             taxon_base_path: taxon.base_path,
             link_href: link.attr('href'),
+            total_number_of_links: "N/A",
             total_number_of_links_per_section: 'N/A',
             navigation_page_type: taxon.navigation_page_type,
             section: 'grid',
@@ -44,6 +45,7 @@ module Analysers
           results << {
             taxon_base_path: taxon.base_path,
             link_href: link.attr('href'),
+            total_number_of_links: section_links_total,
             total_number_of_links_per_section: section_links_total,
             navigation_page_type: taxon.navigation_page_type,
             section: 'leaf',

--- a/lib/css_selector.rb
+++ b/lib/css_selector.rb
@@ -6,6 +6,7 @@ class CssSelector
       accordion_subsection: '.subsection',
       accordion_subsection_title: '.subsection-title',
       leaf_content_item_links: '.parent-topic-contents ol li a',
+      leaf_subsection: '.parent-topic-contents',
     }
   end
 

--- a/lib/tasks/analyse/links.rb
+++ b/lib/tasks/analyse/links.rb
@@ -128,6 +128,8 @@ namespace :analyse do
       taxon_base_path
       section
       link_href
+      number_of_tags
+      taxon_base_paths
     ].freeze
   end
 

--- a/lib/tasks/analyse/links.rb
+++ b/lib/tasks/analyse/links.rb
@@ -126,6 +126,7 @@ namespace :analyse do
     %i[
       navigation_page_type
       taxon_base_path
+      total_number_of_links
       total_number_of_links_per_section
       section
       link_href

--- a/lib/tasks/analyse/links.rb
+++ b/lib/tasks/analyse/links.rb
@@ -126,6 +126,7 @@ namespace :analyse do
     %i[
       navigation_page_type
       taxon_base_path
+      total_number_of_links_per_section
       section
       link_href
       number_of_tags

--- a/spec/lib/analysers/taxons/accordion_link_analyser_spec.rb
+++ b/spec/lib/analysers/taxons/accordion_link_analyser_spec.rb
@@ -26,25 +26,33 @@ RSpec.describe Analysers::Taxons::AccordionLinkAnalyser, '#analyse' do
             taxon_base_path: '/root-taxon',
             link_href: '/path-0-0',
             navigation_page_type: 'accordion',
-            section: 'Subsection 0'
+            section: 'Subsection 0',
+            number_of_tags: 1,
+            taxon_base_paths: "taxon-0"
           },
           {
             taxon_base_path: '/root-taxon',
             link_href: '/path-0-1',
             navigation_page_type: 'accordion',
             section: 'Subsection 0',
+            number_of_tags: 1,
+            taxon_base_paths: "taxon-0"
           },
           {
             taxon_base_path: '/root-taxon',
             link_href: '/path-1-0',
             navigation_page_type: 'accordion',
             section: 'Subsection 1',
+            number_of_tags: 1,
+            taxon_base_paths: "taxon-1"
           },
           {
             taxon_base_path: '/root-taxon',
             link_href: '/path-1-1',
             navigation_page_type: 'accordion',
             section: 'Subsection 1',
+            number_of_tags: 1,
+            taxon_base_paths: "taxon-1"
           },
         )
       end

--- a/spec/lib/analysers/taxons/accordion_link_analyser_spec.rb
+++ b/spec/lib/analysers/taxons/accordion_link_analyser_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Analysers::Taxons::AccordionLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/path-0-0',
+            total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 0',
             number_of_tags: 1,
@@ -33,6 +34,7 @@ RSpec.describe Analysers::Taxons::AccordionLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/path-0-1',
+            total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 0',
             number_of_tags: 1,
@@ -41,6 +43,7 @@ RSpec.describe Analysers::Taxons::AccordionLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/path-1-0',
+            total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 1',
             number_of_tags: 1,
@@ -49,6 +52,7 @@ RSpec.describe Analysers::Taxons::AccordionLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/path-1-1',
+            total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 1',
             number_of_tags: 1,

--- a/spec/lib/analysers/taxons/accordion_link_analyser_spec.rb
+++ b/spec/lib/analysers/taxons/accordion_link_analyser_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Analysers::Taxons::AccordionLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/path-0-0',
+            total_number_of_links: 4,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 0',
@@ -34,6 +35,7 @@ RSpec.describe Analysers::Taxons::AccordionLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/path-0-1',
+            total_number_of_links: 4,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 0',
@@ -43,6 +45,7 @@ RSpec.describe Analysers::Taxons::AccordionLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/path-1-0',
+            total_number_of_links: 4,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 1',
@@ -52,6 +55,7 @@ RSpec.describe Analysers::Taxons::AccordionLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/path-1-1',
+            total_number_of_links: 4,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 1',

--- a/spec/lib/analysers/taxons/grid_and_leaf_link_analyser_spec.rb
+++ b/spec/lib/analysers/taxons/grid_and_leaf_link_analyser_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-0',
+            total_number_of_links_per_section: 'N/A',
             navigation_page_type: 'grid',
             section: 'grid',
             number_of_tags: 'N/A',
@@ -35,6 +36,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-1',
+            total_number_of_links_per_section: 'N/A',
             navigation_page_type: 'grid',
             section: 'grid',
             number_of_tags: 'N/A',
@@ -56,6 +58,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-0',
+            total_number_of_links_per_section: "N/A",
             navigation_page_type: 'grid',
             section: 'grid',
             number_of_tags: 'N/A',
@@ -64,6 +67,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-1',
+            total_number_of_links_per_section: "N/A",
             navigation_page_type: 'grid',
             section: 'grid',
             number_of_tags: 'N/A',
@@ -72,6 +76,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-0',
+            total_number_of_links_per_section: 2,
             navigation_page_type: 'grid',
             section: 'leaf',
             number_of_tags: 1,
@@ -80,6 +85,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-1',
+            total_number_of_links_per_section: 2,
             navigation_page_type: 'grid',
             section: 'leaf',
             number_of_tags: 1,
@@ -112,6 +118,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-0',
+            total_number_of_links_per_section: 2,
             navigation_page_type: 'leaf',
             section: 'leaf',
             number_of_tags: 1,
@@ -120,6 +127,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-1',
+            total_number_of_links_per_section: 2,
             navigation_page_type: 'leaf',
             section: 'leaf',
             number_of_tags: 1,

--- a/spec/lib/analysers/taxons/grid_and_leaf_link_analyser_spec.rb
+++ b/spec/lib/analysers/taxons/grid_and_leaf_link_analyser_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-0',
+            total_number_of_links: 'N/A',
             total_number_of_links_per_section: 'N/A',
             navigation_page_type: 'grid',
             section: 'grid',
@@ -36,6 +37,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-1',
+            total_number_of_links: 'N/A',
             total_number_of_links_per_section: 'N/A',
             navigation_page_type: 'grid',
             section: 'grid',
@@ -58,6 +60,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-0',
+            total_number_of_links: "N/A",
             total_number_of_links_per_section: "N/A",
             navigation_page_type: 'grid',
             section: 'grid',
@@ -67,6 +70,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-1',
+            total_number_of_links: "N/A",
             total_number_of_links_per_section: "N/A",
             navigation_page_type: 'grid',
             section: 'grid',
@@ -76,6 +80,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-0',
+            total_number_of_links: 2,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'grid',
             section: 'leaf',
@@ -85,6 +90,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-1',
+            total_number_of_links: 2,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'grid',
             section: 'leaf',
@@ -118,6 +124,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-0',
+            total_number_of_links: 2,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'leaf',
             section: 'leaf',
@@ -127,6 +134,7 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
           {
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-1',
+            total_number_of_links: 2,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'leaf',
             section: 'leaf',

--- a/spec/lib/analysers/taxons/grid_and_leaf_link_analyser_spec.rb
+++ b/spec/lib/analysers/taxons/grid_and_leaf_link_analyser_spec.rb
@@ -28,13 +28,17 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-0',
             navigation_page_type: 'grid',
-            section: 'grid'
+            section: 'grid',
+            number_of_tags: 'N/A',
+            taxon_base_paths: 'N/A'
           },
           {
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-1',
             navigation_page_type: 'grid',
-            section: 'grid'
+            section: 'grid',
+            number_of_tags: 'N/A',
+            taxon_base_paths: 'N/A'
           },
         )
       end
@@ -53,25 +57,33 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-0',
             navigation_page_type: 'grid',
-            section: 'grid'
+            section: 'grid',
+            number_of_tags: 'N/A',
+            taxon_base_paths: 'N/A'
           },
           {
             taxon_base_path: '/root-taxon',
             link_href: '/taxon-1',
             navigation_page_type: 'grid',
-            section: 'grid'
+            section: 'grid',
+            number_of_tags: 'N/A',
+            taxon_base_paths: 'N/A'
           },
           {
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-0',
             navigation_page_type: 'grid',
-            section: 'leaf'
+            section: 'leaf',
+            number_of_tags: 1,
+            taxon_base_paths: 'taxon-0'
           },
           {
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-1',
             navigation_page_type: 'grid',
-            section: 'leaf'
+            section: 'leaf',
+            number_of_tags: 1,
+            taxon_base_paths: 'taxon-1'
           },
         )
       end
@@ -101,13 +113,17 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-0',
             navigation_page_type: 'leaf',
-            section: 'leaf'
+            section: 'leaf',
+            number_of_tags: 1,
+            taxon_base_paths: 'taxon-0'
           },
           {
             taxon_base_path: '/root-taxon',
             link_href: '/content-item-1',
             navigation_page_type: 'leaf',
-            section: 'leaf'
+            section: 'leaf',
+            number_of_tags: 1,
+            taxon_base_paths: 'taxon-1'
           },
         )
       end

--- a/spec/lib/helpers/body_html.rb
+++ b/spec/lib/helpers/body_html.rb
@@ -1,3 +1,5 @@
+require 'webmock'
+
 class BodyHtml
   def self.with_accordion_content_items(number_of_sections:, number_of_content_items:)
     html_string = ''
@@ -15,9 +17,20 @@ class BodyHtml
             <ol>"
 
       number_of_content_items.times do |content_item_index|
+        base_path = "/path-#{section_index}-#{content_item_index}"
+
+        content_item = {
+          'links' => {
+            'taxons' => [ 'base_path' => "taxon-#{section_index}" ]
+          }
+        }.to_json
+
+        WebMock.stub_request(:get, "https://www.gov.uk/api/content#{base_path}").
+          to_return(body: content_item)
+
         html_string +=
           "<li>
-            <a href='/path-#{section_index}-#{content_item_index}'>
+            <a href='#{base_path}'>
               Content Item #{section_index}-#{content_item_index}
             </a>
           </li>"
@@ -59,9 +72,19 @@ class BodyHtml
           <ol>"
 
     number_of_content_items.times do |content_item_index|
+      base_path = "/content-item-#{content_item_index}"
+      content_item = {
+        'links' => {
+          'taxons' => [ 'base_path' => "taxon-#{content_item_index}" ]
+        }
+      }.to_json
+
+      WebMock.stub_request(:get, "https://www.gov.uk/api/content#{base_path}").
+        to_return(body: content_item)
+
       html_string +=
         "<li>
-          <a href='/content-item-#{content_item_index}'>
+          <a href='#{base_path}'>
             Content Item #{content_item_index}
           </a>
         </li>"


### PR DESCRIPTION
This commit adds 2 new fields to the Google Sheet for analysis:

- number of taxon tags a given content item has;
- the base paths of those taxons, separated by `;`.
- The total number of links per taxon
- The total number of links per section 

Trello: https://trello.com/c/IghwaHOd/193-add-more-tagging-details-to-the-tagging-monitor%27s-monthly-export

Example output: https://docs.google.com/spreadsheets/d/1uu-h_v4uc04Aj6hTCjHK3zqTIBJMRePBIoJm9_zOiMU/edit#gid=0

