### PR TITLE
Display 'all' value for grid 'Number of hrefs'

### DIFF
--- a/lib/tasks/analyse/links.rb
+++ b/lib/tasks/analyse/links.rb
@@ -86,7 +86,7 @@ namespace :analyse do
 
       results_by_taxon_base_path.each_pair do |taxon_base_path, base_path_results|
 
-        if navigation_page_type == 'accordion'
+        if navigation_page_type != 'leaf'
           base_path_results += base_path_results.map do |result|
             result.merge(section: 'all')
           end


### PR DESCRIPTION
[Trello](https://trello.com/c/SWgsHqS0/195-add-number-of-links-details-to-the-tagging-monitors-monthly-export)

- This is needed for grids as some grid pages have leaf sections, resulting in two 'Number of href' values
- 'all' displays the total hrefs for grid pages, which will include the leaf hrefs if they exist
- Example of a page which combines grid and leaf layout: https://www.gov.uk/education/further-and-higher-education-skills-and-vocational-training

<img width="526" alt="all-value-for-grid" src="https://user-images.githubusercontent.com/5963488/27093372-4d4e57e8-505e-11e7-9e1b-4b1b07c95f1e.png">

