### PR TITLE
Rename taxon base path column

### DIFF
--- a/lib/analysers/taxons/accordion_link_analyser.rb
+++ b/lib/analysers/taxons/accordion_link_analyser.rb
@@ -28,14 +28,14 @@ module Analysers
           taxon_base_paths = taxon_tags.map { |taxon| taxon['base_path'] }
 
           results << {
-            taxon_base_path: taxon.base_path,
+            navigation_url: taxon.base_path,
             link_href: link_href,
             total_number_of_links: total_links,
             total_number_of_links_per_section: section_links_total,
             navigation_page_type: taxon.navigation_page_type,
             section: section,
             number_of_tags: number_of_tags,
-            taxon_base_paths: taxon_base_paths.join(';'),
+            navigation_urls: taxon_base_paths.join(';'),
           }
         end
       end

--- a/lib/analysers/taxons/grid_and_leaf_link_analyser.rb
+++ b/lib/analysers/taxons/grid_and_leaf_link_analyser.rb
@@ -15,13 +15,13 @@ module Analysers
             .css(CssSelector.for(:grid_taxon_links)).count
 
           results << {
-            taxon_base_path: taxon.base_path,
+            navigation_url: taxon.base_path,
             link_href: link.attr('href'),
             total_number_of_links: links_total,
             navigation_page_type: taxon.navigation_page_type,
             section: 'grid',
             number_of_tags: 'N/A',
-            taxon_base_paths: 'N/A',
+            navigation_urls: 'N/A',
           }
         end
       end
@@ -45,13 +45,13 @@ module Analysers
           taxon_base_paths = taxon_tags.map { |taxon| taxon['base_path'] }
 
           results << {
-            taxon_base_path: taxon.base_path,
+            navigation_url: taxon.base_path,
             link_href: link.attr('href'),
             total_number_of_links: links_total,
             navigation_page_type: taxon.navigation_page_type,
             section: 'leaf',
             number_of_tags: number_of_tags,
-            taxon_base_paths: taxon_base_paths.join(';'),
+            navigation_urls: taxon_base_paths.join(';'),
           }
         end
       end

--- a/lib/tasks/analyse/links.rb
+++ b/lib/tasks/analyse/links.rb
@@ -71,7 +71,7 @@ namespace :analyse do
     worksheet = spreadsheet.add_worksheet('Taxons')
 
     add_row(
-      data: human_friendly(%w[navigation_page_type taxon_base_path section number_of_hrefs content_regex]),
+      data: human_friendly(%w[navigation_page_type navigation_url section number_of_hrefs content_regex]),
       row_number: 1,
       worksheet: worksheet,
     )
@@ -82,21 +82,21 @@ namespace :analyse do
 
     results_by_navigation_page_type.each_pair do |navigation_page_type, page_type_results|
 
-      results_by_taxon_base_path = group_results(page_type_results, :taxon_base_path)
+      results_by_navigation_url = group_results(page_type_results, :navigation_url)
 
-      results_by_taxon_base_path.each_pair do |taxon_base_path, base_path_results|
+      results_by_navigation_url.each_pair do |navigation_url, navigation_url_results|
 
         if navigation_page_type != 'leaf'
-          base_path_results += base_path_results.map do |result|
+          navigation_url_results += navigation_url_results.map do |result|
             result.merge(section: 'all')
           end
         end
 
-        results_by_section = group_results(base_path_results, :section)
+        results_by_section = group_results(navigation_url_results, :section)
 
         results_by_section.each_pair do |section, results|
           add_row(
-            data: [navigation_page_type, taxon_base_path, section, results.count, regex_from_results(results)],
+            data: [navigation_page_type, navigation_url, section, results.count, regex_from_results(results)],
             row_number: row_number += 1,
             worksheet: worksheet,
           )
@@ -131,13 +131,13 @@ namespace :analyse do
   def column_names
     %i[
       navigation_page_type
-      taxon_base_path
+      navigation_url
       total_number_of_links
       total_number_of_links_per_section
       section
       link_href
       number_of_tags
-      taxon_base_paths
+      navigation_urls
     ]
   end
 

--- a/lib/tasks/analyse/links.rb
+++ b/lib/tasks/analyse/links.rb
@@ -133,8 +133,8 @@ namespace :analyse do
       navigation_page_type
       navigation_url
       total_number_of_links
-      total_number_of_links_per_section
       section
+      total_number_of_links_per_section
       link_href
       number_of_tags
       navigation_urls

--- a/spec/lib/analysers/taxons/accordion_link_analyser_spec.rb
+++ b/spec/lib/analysers/taxons/accordion_link_analyser_spec.rb
@@ -23,44 +23,44 @@ RSpec.describe Analysers::Taxons::AccordionLinkAnalyser, '#analyse' do
         results = @analyser.analyse(@taxon)
         expect(results).to contain_exactly(
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/path-0-0',
             total_number_of_links: 4,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 0',
             number_of_tags: 1,
-            taxon_base_paths: "taxon-0"
+            navigation_urls: "taxon-0"
           },
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/path-0-1',
             total_number_of_links: 4,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 0',
             number_of_tags: 1,
-            taxon_base_paths: "taxon-0"
+            navigation_urls: "taxon-0"
           },
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/path-1-0',
             total_number_of_links: 4,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 1',
             number_of_tags: 1,
-            taxon_base_paths: "taxon-1"
+            navigation_urls: "taxon-1"
           },
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/path-1-1',
             total_number_of_links: 4,
             total_number_of_links_per_section: 2,
             navigation_page_type: 'accordion',
             section: 'Subsection 1',
             number_of_tags: 1,
-            taxon_base_paths: "taxon-1"
+            navigation_urls: "taxon-1"
           },
         )
       end

--- a/spec/lib/analysers/taxons/grid_and_leaf_link_analyser_spec.rb
+++ b/spec/lib/analysers/taxons/grid_and_leaf_link_analyser_spec.rb
@@ -25,22 +25,22 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
 
         expect(results).to contain_exactly(
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/taxon-0',
             total_number_of_links: 2,
             navigation_page_type: 'grid',
             section: 'grid',
             number_of_tags: 'N/A',
-            taxon_base_paths: 'N/A'
+            navigation_urls: 'N/A'
           },
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/taxon-1',
             total_number_of_links: 2,
             navigation_page_type: 'grid',
             section: 'grid',
             number_of_tags: 'N/A',
-            taxon_base_paths: 'N/A'
+            navigation_urls: 'N/A'
           },
         )
       end
@@ -56,40 +56,40 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
 
         expect(results).to contain_exactly(
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/taxon-0',
             total_number_of_links: 2,
             navigation_page_type: 'grid',
             section: 'grid',
             number_of_tags: 'N/A',
-            taxon_base_paths: 'N/A'
+            navigation_urls: 'N/A'
           },
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/taxon-1',
             total_number_of_links: 2,
             navigation_page_type: 'grid',
             section: 'grid',
             number_of_tags: 'N/A',
-            taxon_base_paths: 'N/A'
+            navigation_urls: 'N/A'
           },
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/content-item-0',
             total_number_of_links: 2,
             navigation_page_type: 'grid',
             section: 'leaf',
             number_of_tags: 1,
-            taxon_base_paths: 'taxon-0'
+            navigation_urls: 'taxon-0'
           },
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/content-item-1',
             total_number_of_links: 2,
             navigation_page_type: 'grid',
             section: 'leaf',
             number_of_tags: 1,
-            taxon_base_paths: 'taxon-1'
+            navigation_urls: 'taxon-1'
           },
         )
       end
@@ -116,22 +116,22 @@ RSpec.describe Analysers::Taxons::GridAndLeafLinkAnalyser, '#analyse' do
 
         expect(results).to contain_exactly(
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/content-item-0',
             total_number_of_links: 2,
             navigation_page_type: 'leaf',
             section: 'leaf',
             number_of_tags: 1,
-            taxon_base_paths: 'taxon-0'
+            navigation_urls: 'taxon-0'
           },
           {
-            taxon_base_path: '/root-taxon',
+            navigation_url: '/root-taxon',
             link_href: '/content-item-1',
             total_number_of_links: 2,
             navigation_page_type: 'leaf',
             section: 'leaf',
             number_of_tags: 1,
-            taxon_base_paths: 'taxon-1'
+            navigation_urls: 'taxon-1'
           },
         )
       end


### PR DESCRIPTION
[Trello](https://trello.com/c/dygHDP83/239-rename-taxon-base-path-column-in-tagging-monitor-export)

<img width="1247" alt="renamed-reordered" src="https://user-images.githubusercontent.com/5963488/27431184-811dddd2-5743-11e7-86bc-7cf9d4dc571a.png">

[Example](https://docs.google.com/spreadsheets/d/1LnbTQlnMuGX_Uo6UXs5j-9ke6xa4AMT1bb4mqGL46yY/edit#gid=0)