### PR TITLE
Update CSS Selectors for taxon analyser

### DIFF
--- a/lib/css_selector.rb
+++ b/lib/css_selector.rb
@@ -3,11 +3,11 @@ class CssSelector
     {
       grid_subsection: '.child-topics-list',
       grid_taxon_links: '.child-topics-list ol li a',
-      accordion_content_item_links: '.subsection-content ol li a',
-      accordion_subsection: '.subsection',
-      accordion_subsection_title: '.subsection-title',
-      leaf_content_item_links: '.parent-topic-contents ol li a',
-      leaf_subsection: '.parent-topic-contents',
+      accordion_content_item_links: '.app-c-accordion__panel ol li a',
+      accordion_subsection: '.app-c-accordion__section',
+      accordion_subsection_title: '.app-c-accordion__title',
+      leaf_content_item_links: '.app-c-taxon-list__link',
+      leaf_subsection: '.app-c-taxon-list__item',
       blue_box_links: '.high-volume li a',
     }
   end

--- a/spec/lib/helpers/body_html.rb
+++ b/spec/lib/helpers/body_html.rb
@@ -24,13 +24,13 @@ class BodyHtml
     number_of_sections.times do |section_index|
       html_string +=
         "<div class='topic-content'>
-           <div class='subsection'>
-             <div class='subsection-header'>
-               <h2 class='subsection-title'>
+           <div class='app-c-accordion__section'>
+             <div class='app-c-accordion__header'>
+               <h2 class='app-c-accordion__title'>
                  Subsection #{section_index}
                </h2>
              </div>
-             <div class='subsection-content'>
+             <div class='app-c-accordion__panel'>
                <ol>"
 
       number_of_content_items.times do |content_item_index|
@@ -85,7 +85,7 @@ class BodyHtml
       </nav>"
 
     html_string +=
-      "<div class='parent-topic-contents'>
+      "<div class='app-c-taxon-list__item'>
         <div class='topic-content'>
           <ol>"
 
@@ -103,7 +103,7 @@ class BodyHtml
 
       html_string +=
         "<li>
-          <a href='#{base_path}'>
+          <a class='app-c-taxon-list__link' href='#{base_path}'>
             Content Item #{content_item_index}
           </a>
         </li>"


### PR DESCRIPTION
The taxon pages were recently 'component'-ised so the mark up changed for some of the elements. This led to the Taxon Analyser rake task to report failures (also in the taxonomy team Slack channel). 
This commit updates the selectors to make the tests pass again.

For reference, see:
https://github.com/alphagov/collections/pull/398
https://github.com/alphagov/collections/pull/394