### PR TITLE
Add taggable items to global stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ gem "rspec"
 gem "webmock"
 gem "colorize"
 gem "google_drive", "~> 2.1"
-gem "gds-api-adapters"
+gem 'gds-api-adapters', '~> 46.0'
+gem 'plek', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     plek (2.0.0)
     public_suffix (2.0.5)
     rack (2.0.3)
-    rack-cache (1.7.0)
+    rack-cache (1.7.1)
       rack (>= 0.4)
     rake (12.0.0)
     representable (3.0.4)
@@ -121,9 +121,10 @@ PLATFORMS
 
 DEPENDENCIES
   colorize
-  gds-api-adapters
+  gds-api-adapters (~> 46.0)
   google_drive (~> 2.1)
   nokogiri
+  plek (~> 2.0)
   rake
   rspec
   statsd-ruby
@@ -131,4 +132,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/lib/global_stats.rb
+++ b/lib/global_stats.rb
@@ -1,86 +1,95 @@
-require 'gds_api/rummager'
-
 class GlobalStats
   include StatsHelpers
 
+  GOVUK_ROOT_CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a".freeze
+
   BLACKLIST_DOCUMENT_TYPES = %w[
-      redirect
-      staff_update
-      coming_soon
-      travel_advice
-      html_publication
-      manual_section
-      hmrc_manual_section
-      contact
-      completed_transaction
-      service_standard_report
-      employment_tribunal_decision
-      tax_tribunal_decision
-      utaac_decision
-      dfid_research_output
-      asylum_support_decision
-      employment_appeal_tribunal_decision
-      cma_case
-      need
-      working_group
-      organisation
-      person
-      worldwide_organisation
-      world_location
-      topical_event
-      policy_area
-      field_of_operation
-      ministerial_role
-      topical_event_about_page
-      finder_email_signup
-      mainstream_browse_page
-      topic
-      homepage
-      licence_finder
-      search
-      taxon
-      travel_advice_index
-      business_support_finder
-      finder
-      about
-      about_our_services
-      personal_information_charter
-      equality_and_diversity
-      our_governance
-      services_and_information
-      our_energy_use
-      corporate_report
-      social_media_use
-      access_and_opening
-      membership
-      publication_scheme
-      media_enquiries
-      complaints_procedure
-      help_page
-      service_manual_homepage
-      service_manual_service_toolkit
-      service_manual_service_standard
-      service_manual_guide
-      service_manual_topic
-      gone
-    ].freeze
+    redirect
+    staff_update
+    coming_soon
+    travel_advice
+    html_publication
+    manual_section
+    hmrc_manual_section
+    contact
+    completed_transaction
+    service_standard_report
+    employment_tribunal_decision
+    tax_tribunal_decision
+    utaac_decision
+    dfid_research_output
+    asylum_support_decision
+    employment_appeal_tribunal_decision
+    cma_case
+    need
+    working_group
+    organisation
+    person
+    worldwide_organisation
+    world_location
+    topical_event
+    policy_area
+    field_of_operation
+    ministerial_role
+    topical_event_about_page
+    finder_email_signup
+    mainstream_browse_page
+    topic
+    homepage
+    licence_finder
+    search
+    taxon
+    travel_advice_index
+    business_support_finder
+    finder
+    about
+    about_our_services
+    personal_information_charter
+    equality_and_diversity
+    our_governance
+    services_and_information
+    our_energy_use
+    corporate_report
+    social_media_use
+    access_and_opening
+    membership
+    publication_scheme
+    media_enquiries
+    complaints_procedure
+    help_page
+    service_manual_homepage
+    service_manual_service_toolkit
+    service_manual_service_standard
+    service_manual_guide
+    service_manual_topic
+    gone
+  ].freeze
 
   def run
-    total_items = Services.rummager.search(count: 0,
-                                           debug: 'include_withdrawn').to_h.fetch("total")
+    total_items = Services.rummager.search(
+      count: 0,
+      debug: 'include_withdrawn'
+    ).to_h.fetch("total")
 
-    taggable_items = Services.rummager.search(count: 0,
-                                              reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
-                                              debug: 'include_withdrawn').to_h.fetch("total")
+    taggable_items = Services.rummager.search(
+      count: 0,
+      reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
+      debug: 'include_withdrawn'
+    ).to_h.fetch("total")
 
-    untagged_items = Services.rummager.search(count: 0,
-                                              filter_taxons: '_MISSING',
-                                              reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
-                                              debug: 'include_withdrawn').to_h.fetch("total")
+    root_taxons = Services.publishing_api.get_links(GOVUK_ROOT_CONTENT_ID)
+                    .to_h.dig("links", "root_taxons")
+
+    tagged_items = Services.rummager.search(
+      count: 0,
+      filter_part_of_taxonomy_tree: root_taxons,
+      reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
+      debug: 'include_withdrawn'
+    ).to_h.fetch("total")
 
     gauge "items", total_items
     gauge "taggable_items", taggable_items
-    gauge "items_without_taxons", untagged_items
-    gauge "items_with_taxons", taggable_items - untagged_items
+    gauge "taggable_items_with_taxons", tagged_items
+    gauge "taggable_items_without_taxons", taggable_items - tagged_items
   end
 end

--- a/lib/global_stats.rb
+++ b/lib/global_stats.rb
@@ -66,30 +66,33 @@ class GlobalStats
   ].freeze
 
   def run
-    total_items = Services.rummager.search(
+    items = Services.rummager.search(
       count: 0,
       debug: 'include_withdrawn'
     ).to_h.fetch("total")
 
-    taggable_items = Services.rummager.search(
+    items_in_scope = Services.rummager.search(
       count: 0,
       reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
       debug: 'include_withdrawn'
     ).to_h.fetch("total")
 
-    root_taxons = Services.publishing_api.get_links(GOVUK_ROOT_CONTENT_ID)
-                    .to_h.dig("links", "root_taxons")
-
-    tagged_items = Services.rummager.search(
+    tagged_items_in_scope = Services.rummager.search(
       count: 0,
       filter_part_of_taxonomy_tree: root_taxons,
       reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
       debug: 'include_withdrawn'
     ).to_h.fetch("total")
 
-    gauge "items", total_items
-    gauge "taggable_items", taggable_items
-    gauge "taggable_items_with_taxons", tagged_items
-    gauge "taggable_items_without_taxons", taggable_items - tagged_items
+    gauge "items", items
+    gauge "items_in_scope", items_in_scope
+    gauge "tagged_items_in_scope", tagged_items_in_scope
+    gauge "untagged_items_in_scope", items_in_scope - tagged_items_in_scope
+  end
+
+private
+
+  def root_taxons
+    Services.publishing_api.get_links(GOVUK_ROOT_CONTENT_ID).to_h.dig("links", "root_taxons")
   end
 end

--- a/lib/global_stats.rb
+++ b/lib/global_stats.rb
@@ -1,13 +1,86 @@
+require 'gds_api/rummager'
+
 class GlobalStats
   include StatsHelpers
 
+  BLACKLIST_DOCUMENT_TYPES = %w[
+      redirect
+      staff_update
+      coming_soon
+      travel_advice
+      html_publication
+      manual_section
+      hmrc_manual_section
+      contact
+      completed_transaction
+      service_standard_report
+      employment_tribunal_decision
+      tax_tribunal_decision
+      utaac_decision
+      dfid_research_output
+      asylum_support_decision
+      employment_appeal_tribunal_decision
+      cma_case
+      need
+      working_group
+      organisation
+      person
+      worldwide_organisation
+      world_location
+      topical_event
+      policy_area
+      field_of_operation
+      ministerial_role
+      topical_event_about_page
+      finder_email_signup
+      mainstream_browse_page
+      topic
+      homepage
+      licence_finder
+      search
+      taxon
+      travel_advice_index
+      business_support_finder
+      finder
+      about
+      about_our_services
+      personal_information_charter
+      equality_and_diversity
+      our_governance
+      services_and_information
+      our_energy_use
+      corporate_report
+      social_media_use
+      access_and_opening
+      membership
+      publication_scheme
+      media_enquiries
+      complaints_procedure
+      help_page
+      service_manual_homepage
+      service_manual_service_toolkit
+      service_manual_service_standard
+      service_manual_guide
+      service_manual_topic
+      gone
+    ].freeze
+
   def run
-    total_items = HTTP.get_json("https://www.gov.uk/api/search.json?count=0&debug=include_withdrawn")
-    gauge "items", total_items.fetch("total")
+    total_items = Services.rummager.search(count: 0,
+                                           debug: 'include_withdrawn').to_h.fetch("total")
 
-    untagged_items = HTTP.get_json("https://www.gov.uk/api/search.json?count=0&filter_taxons=_MISSING&debug=include_withdrawn")
-    gauge "items_without_taxons", untagged_items.fetch("total")
+    taggable_items = Services.rummager.search(count: 0,
+                                              reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
+                                              debug: 'include_withdrawn').to_h.fetch("total")
 
-    gauge "items_with_taxons", total_items.fetch("total") - untagged_items.fetch("total")
+    untagged_items = Services.rummager.search(count: 0,
+                                              filter_taxons: '_MISSING',
+                                              reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
+                                              debug: 'include_withdrawn').to_h.fetch("total")
+
+    gauge "items", total_items
+    gauge "taggable_items", taggable_items
+    gauge "items_without_taxons", untagged_items
+    gauge "items_with_taxons", taggable_items - untagged_items
   end
 end

--- a/lib/requires.rb
+++ b/lib/requires.rb
@@ -2,6 +2,8 @@ require 'typhoeus'
 require 'json'
 require 'statsd'
 require 'nokogiri'
+require 'gds_api/publishing_api_v2'
+require 'gds_api/rummager'
 
 require_relative './stats_helpers'
 require_relative './services'

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -4,6 +4,16 @@ module Services
   end
 
   def self.rummager
-    GdsApi::Rummager.new('https://www.gov.uk/api')
+    @rummager ||= GdsApi::Rummager.new(
+      Plek.new.find('rummager')
+    )
+  end
+
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      disable_cache: true,
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+    )
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,4 +2,8 @@ module Services
   def self.statsd
     @statsd ||= Statsd.new
   end
+
+  def self.rummager
+    GdsApi::Rummager.new('https://www.gov.uk/api')
+  end
 end

--- a/lib/tasks/analyse/links.rb
+++ b/lib/tasks/analyse/links.rb
@@ -2,7 +2,6 @@ require 'uri'
 require 'google_drive'
 require 'json'
 require 'set'
-require 'gds_api/rummager'
 
 namespace :analyse do
   desc <<-DESC
@@ -125,8 +124,7 @@ namespace :analyse do
   end
 
   def number_of_content_items_tagged_to_education
-    rummager = GdsApi::Rummager.new('https://www.gov.uk/api')
-    rummager.search(
+    Services.rummager.search(
       filter_part_of_taxonomy_tree: 'c58fdadd-7743-46d6-9629-90bb3ccc4ef0',
       count: 0
     ).to_h['total']

--- a/spec/lib/global_stats_spec.rb
+++ b/spec/lib/global_stats_spec.rb
@@ -7,17 +7,31 @@ RSpec.describe GlobalStats do
 
   describe '#run' do
     it "reports statistics" do
-      stub_request(:get, "https://www.gov.uk/api/search.json?count=0&debug=include_withdrawn").
-        to_return(body: JSON.dump(total: 123))
 
-      stub_request(:get, "https://www.gov.uk/api/search.json?count=0&debug=include_withdrawn&filter_taxons=_MISSING").
+      stub_request(:get, "https://www.gov.uk/api/search.json").
+        with(query: { count: 0,
+                      debug: 'include_withdrawn' }).
+        to_return(body: JSON.dump(total: 1000))
+
+      stub_request(:get, "https://www.gov.uk/api/search.json").
+        with(query: { count: 0,
+                      debug: 'include_withdrawn',
+                      reject_content_store_document_type: GlobalStats::BLACKLIST_DOCUMENT_TYPES }).
+        to_return(body: JSON.dump(total: 500))
+
+      stub_request(:get, "https://www.gov.uk/api/search.json").
+        with(query: { count: 0,
+                      debug: 'include_withdrawn',
+                      filter_taxons: '_MISSING',
+                      reject_content_store_document_type: GlobalStats::BLACKLIST_DOCUMENT_TYPES }).
         to_return(body: JSON.dump(total: 100))
 
       GlobalStats.new.run
 
-      expect(Services.statsd).to have_received(:gauge).with("govuk.tagging.items", 123)
+      expect(Services.statsd).to have_received(:gauge).with("govuk.tagging.items", 1000)
       expect(Services.statsd).to have_received(:gauge).with("govuk.tagging.items_without_taxons", 100)
-      expect(Services.statsd).to have_received(:gauge).with("govuk.tagging.items_with_taxons", 23)
+      expect(Services.statsd).to have_received(:gauge).with("govuk.tagging.taggable_items", 500)
+      expect(Services.statsd).to have_received(:gauge).with("govuk.tagging.items_with_taxons", 400)
     end
   end
 end

--- a/spec/lib/global_stats_spec.rb
+++ b/spec/lib/global_stats_spec.rb
@@ -33,17 +33,19 @@ RSpec.describe GlobalStats do
 
       GlobalStats.new.run
 
-      expect(Services.statsd).to have_received(:gauge)
-        .with("govuk.tagging.items", 1000)
+      aggregate_failures "metrics" do
+        expect(Services.statsd).to have_received(:gauge)
+          .with("govuk.tagging.items", 1000)
 
-      expect(Services.statsd).to have_received(:gauge)
-        .with("govuk.tagging.taggable_items", 500)
+        expect(Services.statsd).to have_received(:gauge)
+          .with("govuk.tagging.items_in_scope", 500)
 
-      expect(Services.statsd).to have_received(:gauge)
-        .with("govuk.tagging.taggable_items_with_taxons", 400)
+        expect(Services.statsd).to have_received(:gauge)
+          .with("govuk.tagging.tagged_items_in_scope", 400)
 
-      expect(Services.statsd).to have_received(:gauge)
-        .with("govuk.tagging.taggable_items_without_taxons", 100)
+        expect(Services.statsd).to have_received(:gauge)
+          .with("govuk.tagging.untagged_items_in_scope", 100)
+      end
     end
   end
 end

--- a/spec/lib/global_stats_spec.rb
+++ b/spec/lib/global_stats_spec.rb
@@ -7,31 +7,43 @@ RSpec.describe GlobalStats do
 
   describe '#run' do
     it "reports statistics" do
+      stub_request(:get, "http://rummager.dev.gov.uk/search.json")
+        .with(query: {
+          count: 0,
+          debug: 'include_withdrawn'
+        }).to_return(body: JSON.dump(total: 1000))
 
-      stub_request(:get, "https://www.gov.uk/api/search.json").
-        with(query: { count: 0,
-                      debug: 'include_withdrawn' }).
-        to_return(body: JSON.dump(total: 1000))
+      stub_request(:get, "http://rummager.dev.gov.uk/search.json")
+        .with(query: {
+          count: 0,
+          debug: 'include_withdrawn',
+          reject_content_store_document_type: GlobalStats::BLACKLIST_DOCUMENT_TYPES
+        }).to_return(body: JSON.dump(total: 500))
 
-      stub_request(:get, "https://www.gov.uk/api/search.json").
-        with(query: { count: 0,
-                      debug: 'include_withdrawn',
-                      reject_content_store_document_type: GlobalStats::BLACKLIST_DOCUMENT_TYPES }).
-        to_return(body: JSON.dump(total: 500))
+      stub_request(:get, "http://publishing-api.dev.gov.uk/v2/links/f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a")
+        .to_return(body: JSON.dump(links: { root_taxons: ['aaaa-bbbb', 'cccc-dddd'] }))
 
-      stub_request(:get, "https://www.gov.uk/api/search.json").
-        with(query: { count: 0,
-                      debug: 'include_withdrawn',
-                      filter_taxons: '_MISSING',
-                      reject_content_store_document_type: GlobalStats::BLACKLIST_DOCUMENT_TYPES }).
-        to_return(body: JSON.dump(total: 100))
+      stub_request(:get, "http://rummager.dev.gov.uk/search.json")
+        .with(query: {
+          count: 0,
+          debug: 'include_withdrawn',
+          filter_part_of_taxonomy_tree: ['aaaa-bbbb', 'cccc-dddd'],
+          reject_content_store_document_type: GlobalStats::BLACKLIST_DOCUMENT_TYPES
+        }).to_return(body: JSON.dump(total: 400))
 
       GlobalStats.new.run
 
-      expect(Services.statsd).to have_received(:gauge).with("govuk.tagging.items", 1000)
-      expect(Services.statsd).to have_received(:gauge).with("govuk.tagging.items_without_taxons", 100)
-      expect(Services.statsd).to have_received(:gauge).with("govuk.tagging.taggable_items", 500)
-      expect(Services.statsd).to have_received(:gauge).with("govuk.tagging.items_with_taxons", 400)
+      expect(Services.statsd).to have_received(:gauge)
+        .with("govuk.tagging.items", 1000)
+
+      expect(Services.statsd).to have_received(:gauge)
+        .with("govuk.tagging.taggable_items", 500)
+
+      expect(Services.statsd).to have_received(:gauge)
+        .with("govuk.tagging.taggable_items_with_taxons", 400)
+
+      expect(Services.statsd).to have_received(:gauge)
+        .with("govuk.tagging.taggable_items_without_taxons", 100)
     end
   end
 end


### PR DESCRIPTION
Add the metric 'taggable items' to the global stats. These are the number of content items that have content types that can be associated with taxons. Examples of omitted content items are for instance those with content type of 'taxon' or 'redirect'

trello: https://trello.com/c/EFBUZnQs/172-implement-tracking-for-a-metric-which-describes-how-much-content-is-in-scope-for-tagging-to-the-taxonomy